### PR TITLE
contracts: move verifier into constructor

### DIFF
--- a/integration/contracts/MyPool.sol
+++ b/integration/contracts/MyPool.sol
@@ -8,7 +8,7 @@ contract MyPool is ZRC20 {
 
     uint256 public mintedAmount;
 
-    constructor() ZRC20("MyPool", "MP") {}
+    constructor(address verifierAddress) ZRC20("MyPool", "MP", verifierAddress) {}
 
     function mint(uint256 amount, bytes memory proof, uint[] memory pubSignals) public override {
         super.mint(amount, proof, pubSignals);

--- a/integration/test/MyPool.ts
+++ b/integration/test/MyPool.ts
@@ -4,14 +4,18 @@ import { plonk } from "snarkjs";
 
 it("Should work", async function () {
   const MyPool = await ethers.getContractFactory("MyPool");
-  const pool = await MyPool.deploy();
+  const TransactionVerifier = await ethers.getContractFactory("TransactionVerifier");
+  const verifier = await TransactionVerifier.deploy();
+  console.log("verifier address: " + verifier.address);
+  const pool = await MyPool.deploy(verifier.address);
 
   const proof = await generateProof(1, 2, 2);
   //console.log(proof);
 
   const mintAmount = 10;
-  await (await pool.mint(mintAmount, proof, [2])).wait();
-  console.log(await pool.mintedAmount());
+  await pool.mint(mintAmount, proof, [2]);
+  const mintedAmount = await pool.mintedAmount();
+  console.log("mintedAmount: " + mintedAmount);
 });
 
 async function generateProof(a: number, b: number, c: number): Promise<string> {

--- a/tools/contracts/ZRC20.sol
+++ b/tools/contracts/ZRC20.sol
@@ -9,10 +9,10 @@ contract ZRC20 {
     string private _symbol;
     TransactionVerifier public verifier;
 
-    constructor(string memory name_, string memory symbol_) {
+    constructor(string memory name_, string memory symbol_, address verifierAddress) {
         _name = name_;
         _symbol = symbol_;
-        verifier = TransactionVerifier(0xA836380122e58Dff60D3404d8994671b0eF6CCd8);
+        verifier = TransactionVerifier(verifierAddress);
     }
 
     function mint(uint256 amount, bytes memory proof, uint[] memory pubSignals) public virtual {


### PR DESCRIPTION
This pull request aims to discuss a method of integrating the verifier into external contracts without causing significant bytecode size increase for ZRC20. The main goal is to maintain network compatibility while ensuring the test code runs smoothly.

Initially, the verifier was deployed on the Goerli testnet at the address 0xA836380122e58Dff60D3404d8994671b0eF6CCd8, which limited its functionality to that network. To overcome this limitation, I moved the verifier into the contract constructor and dynamically deployed it within the test code. As a result, `pnpm test` now executes without any errors.

Although it may seem reasonable to make ZRC20 inherit from TransactionVerifier, I have reservations about this approach. Inheriting from TransactionVerifier could significantly increase the bytecode size of ZRC20 without offering any notable benefits.

I prefer to not make ZRC20 inherit from TransactionVerifier. Not sure if there are any special benefits of inheriting from TransactionVerifier?

