### PR TITLE
fix ForceEqualIfEnabled constraint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Build circom repository
         run: cd circom && cargo build --release && cargo install --path circom
-        if: steps.circom-cache.outputs.cache_changed == 'true'
+        if: steps.circom-cache.outputs.cache-hit != 'true'
         env:
           CARGO_HOME: ${{ runner.workspace }}/cargo
           RUSTUP_HOME: ${{ runner.workspace }}/rustup

--- a/sdk/circuits/compliant.circom
+++ b/sdk/circuits/compliant.circom
@@ -72,7 +72,7 @@ template CompliantTransaction(levels, nIns, nOuts, zeroLeaf) {
     inCheckAsset = ForceEqualIfEnabled();
     inCheckAsset.in[0] <== asset;
     inCheckAsset.in[1] <== publicAsset;
-    inCheckAsset.enabled <-- (publicAsset == 0) ? 0 : 1;
+    inCheckAsset.enabled <== publicAsset; // publicAsset as zero means not enabled
 
     // check that inputs are not in blocklist
     component checkInputs = CheckBlocklist(levels, nIns);

--- a/sdk/circuits/transaction.circom
+++ b/sdk/circuits/transaction.circom
@@ -54,7 +54,7 @@ template Transaction(levels, nIns, nOuts, zeroLeaf) {
     inCheckAsset = ForceEqualIfEnabled();
     inCheckAsset.in[0] <== asset;
     inCheckAsset.in[1] <== publicAsset;
-    inCheckAsset.enabled <-- (publicAsset == 0) ? 0 : 1;
+    inCheckAsset.enabled <== publicAsset; // publicAsset as zero means not enabled
 
     // verify correctness of transaction inputs
     for (var tx = 0; tx < nIns; tx++) {


### PR DESCRIPTION
https://docs.circom.io/circom-language/signals/

>Signals can only be assigned using the operations <-- or <== (see [Basic operators](https://docs.circom.io/circom-language/basic-operators)) with the signal on the left hand side and --> or ==> (see [Basic operators](https://docs.circom.io/circom-language/basic-operators)) with the signal on the right hand side. The safe options are <== and ==>, since they assign values and also generate constraints at the same time. Using <-- and --> is, in general, dangerous and should only be used when the assigned expression cannot be included in a constraint, like in the following example.

Similar to Tornado Cash MIMC Hash Vulnerability in 2019.

---

https://tornado-cash.medium.com/tornado-cash-got-hacked-by-us-b1e012a3c9a8

> The bug was found by Kobi Gurkan in the zk-SNARK implementation of the MIMC hash function in circomlib, that is used in Tornado for building the merkle tree of deposits. If everything works as expected, users prove that they have committed a leaf to that tree during deposit without revealing the commitment itself. The buggy version did not check that resulting MIMC hash is correct. The fix is simple: instead of using the `=` operator the `<==` operator should be used.

https://blog.trailofbits.com/2022/09/15/it-pays-to-be-circomspect/

> In the case of Tornado.cash, it turned out that the MIMC hash function used to compute the Merkle tree root in the proof used only the assignment operator <-- when defining the output. (Actually, it uses =, as demonstrated in the GitHub diff above. However, in the previous version of the Circom compiler, this was interpreted in the same way as <--. Today, this code would generate a compilation error.) As we have seen, this only assigned a value to the output during proof generation, but did not constrain the output during proof verification, leaving the verifying contract vulnerable.